### PR TITLE
Uncomment topdirectory and set it to root.

### DIFF
--- a/conf/ru.config
+++ b/conf/ru.config
@@ -22,7 +22,7 @@ $log_file = '/tmp/rutorrent_errors.log'; // path to log file (comment or leave b
 $saveUploadedTorrents = true; // Save uploaded torrents to profile/torrents directory or not
 $overwriteUploadedTorrents = false; // Overwrite existing uploaded torrents in profile/torrents directory or make unique name
 
-// $topDirectory = '/home'; // Upper available directory. Absolute path with trail slash.
+$topDirectory = '/'; // Upper available directory. Absolute path with trail slash.
 $forbidUserSettings = false;
 
 // $scgi_port = 5000;


### PR DESCRIPTION
This needs to be set to root in order to properly build torrents.  When trying to build
torrents without this adjustment, my torrents were failing to build
with an error of an improper path.

Signed-off-by: RobbieL811 <robbielancaster811@gmail.com>