### PR TITLE
Minor update to rtinst for arm64

### DIFF
--- a/scripts/rtinst
+++ b/scripts/rtinst
@@ -558,7 +558,7 @@ for package_name in $package_list
 
 # Installs a package needed to prevent arm64 architectures from "WARNING: Unable to start rtorrent"
 if [ "$(uname --m)" == "aarch64" ] || [ "$(dpkg --print-architecture)" == "arm64" ] ; then
-    sudo apt-get install libxmlrpc-core-c3-dev
+    sudo apt-get install libxmlrpc-core-c3-dev -y
 fi
 
 test -z "$install_list" || apt-get -qq install $install_list >> $logfile 2>&1


### PR DESCRIPTION
Add “-y” so the user doesn't need to agree to continue to install the package which is needed for arm64 devices