### PR TITLE
Add fallback for fetching external ip (ipinfo.io)

### DIFF
--- a/scripts/rtinst
+++ b/scripts/rtinst
@@ -239,20 +239,23 @@ fi
 
 serveripa=$(ip route get 8.8.8.8 | awk 'NR==1 {print $7}')
 serveripb=$(wget -qO- --timeout=3 ipecho.net/plain)
+serveripc=$(wget -qO- --timeout=3 ipinfo.io/ip)
 
-if [ "$serveripa" = "$serveripb" ]; then
+if [ "$serveripa" = "$serveripb" ] || [ "$serveripa" = "$serveripc" ]; then
   serverip=$serveripa
 else
   echo "Select the IP address to use:"
   echo "1.) "$serveripa
   echo "2.) "$serveripb
+  echo "3.) "$serveripc
 
   while true
     do
       read answer
       case $answer in [1] ) serverip=$serveripa && break ;;
                       [2] ) serverip=$serveripb && break ;;
-                        * ) echo "Enter 1 or 2";;
+                      [3] ) serverip=$serveripc && break ;;
+                        * ) echo "Enter 1, 2 or 3";;
     esac
   done
 fi


### PR DESCRIPTION
If ipecho is down or the ISP is blocking it, there are no other ways to get external ip. Adding another fallback to ipinfo.io makes the issue that rtinst can't figure out the external ip less likely.

Issue: https://github.com/arakasi72/rtinst/issues/448