### PR TITLE
Fallback if lsb_release -si does not return Ubuntu, Debian or Raspbian

### DIFF
--- a/scripts/rtinst
+++ b/scripts/rtinst
@@ -202,8 +202,8 @@ fullrel=$(lsb_release -sd)
 osname=$(lsb_release -si)
 relno=$(lsb_release -sr | cut -d. -f1)
 
-# Fallback if lsb_release -si returns nothing
-if [ "$osname" = "" ]; then
+# Fallback if lsb_release -si returns anything else than Ubuntu, Debian or Raspbian
+if [ ! "$osname" = "ubuntu" ] && [ ! "$osname" = "debian" ] && [ ! "$osname" = "raspbian" ]; then
   osname=$(grep -oP '(?<=^ID=).+' /etc/os-release | tr -d '"')
   osname=${osname^}
 fi


### PR DESCRIPTION
Adds a fallback if lsb_release -si returns anything else than Ubuntu, Debian or Raspbian.

Should solve https://github.com/arakasi72/rtinst/issues/495. Needs testing and confirmation.