### PR TITLE
Update rtletsencrypt - add -f to make the ln command idempotent

### DIFF
--- a/scripts/rtletsencrypt
+++ b/scripts/rtletsencrypt
@@ -81,7 +81,7 @@ if [ $(snap list | grep -c "certbot") = 0 ]; then
 fi
 
 #Prepare certbot command
-ln -s /snap/bin/certbot /usr/bin/certbot
+ln -sf /snap/bin/certbot /usr/bin/certbot
 
 #Generating Certificates
 certbot -q --nginx --register-unsafely-without-email --agree-tos certonly -d $serverdn >> $logfile 2>&1


### PR DESCRIPTION
Without -f ln commands logs an error message of `ln: failed to create symbolic link '/usr/bin/certbot': File exists`
This will always overwrite the target destination and not error out.