### PR TITLE
Updated rinst to support Ubuntu 22.04

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 
 ### Note: Now installs Lets Encrypt SSL certificates
 
+#### Ubuntu 22.04 now supported 
 #### 30 Second Guide
 
 Ubuntu and Debian Seedbox Installation
@@ -30,6 +31,8 @@ Current release has been tested with clean installs of:
 	Ubuntu 18
 	Ubuntu 19
 	Ubuntu 20
+	Ubuntu 21
+	Ubuntu 22
 	Debian 9 "Stretch"
 	Debian 10 "Buster"
 

--- a/rtsetup
+++ b/rtsetup
@@ -99,6 +99,10 @@ cd
 ln -sf /etc/rtinst/scripts/* /usr/local/bin
 ln -sf /etc/rtinst/rtsetup /usr/local/bin
 
+echo "Adding PHP repositoy"
+apt-get install -yqq software-properties-common 2>&1 >> /dev/null
+add-apt-repository -y ppa:ondrej/php > /dev/null 2>&1
+
 echo "Installation complete"
 echo
 echo "You can now run rtinst and the additional supporting scripts"

--- a/scripts/rtinst
+++ b/scripts/rtinst
@@ -243,7 +243,13 @@ if [ "$relno" = "20" ] || [ "$(lsb_release -sr)" = "20.04" ] || [ "$relno" = "11
   libcver=libcurl4
 fi
 
-if [ "$relno" = "21" ] || [ "$(lsb_release -sr)" = "21.04" ]; then
+if [ "$relno" = "21" ] || [ "$(lsb_release -sr)" = "21.10" ]; then
+  phpver=php7.4
+  phploc=/etc/php/7.4
+  libcver=libcurl4
+fi
+
+if [ "$relno" = "22" ] || [ "$(lsb_release -sr)" = "22.04" ]; then
   phpver=php7.4
   phploc=/etc/php/7.4
   libcver=libcurl4
@@ -287,7 +293,7 @@ sshport=''
 rudevflag=1
 rurelease=master
 passfile='/etc/nginx/.htpasswd'
-package_list="sudo nano autoconf build-essential ca-certificates comerr-dev curl dtach htop irssi libcppunit-dev $libcver libncurses5-dev libterm-readline-gnu-perl libsigc++-2.0-dev libperl-dev libtool libxml2-dev ncurses-base ncurses-term ntp patch pkg-config $phpver-fpm $phpver $phpver-cli $phpver-dev $phpver-curl php-geoip $phpver-xmlrpc $phpver-xml $phpver-zip screen subversion texinfo unzip zlib1g-dev libcurl4-openssl-dev mediainfo software-properties-common $phpver-json nginx-full apache2-utils git libarchive-zip-perl libnet-ssleay-perl libhtml-parser-perl libxml-libxml-perl libjson-perl libjson-xs-perl libxml-libxslt-perl libjson-rpc-perl libarchive-zip-perl"
+package_list="sudo nano autoconf build-essential ca-certificates comerr-dev curl dtach htop irssi libcppunit-dev $libcver libncurses5-dev libterm-readline-gnu-perl libsigc++-2.0-dev libperl-dev libtool libxml2-dev ncurses-base ncurses-term ntp patch pkg-config $phpver-fpm $phpver $phpver-cli $phpver-dev $phpver-curl $phpver-geoip $phpver-xmlrpc $phpver-xml $phpver-zip screen subversion texinfo unzip zlib1g-dev libcurl4-openssl-dev mediainfo software-properties-common $phpver-json nginx-full apache2-utils git libarchive-zip-perl libnet-ssleay-perl libhtml-parser-perl libxml-libxml-perl libjson-perl libjson-xs-perl libxml-libxslt-perl libjson-rpc-perl libarchive-zip-perl"
 Install_list=""
 unixpass=""
 passflag=0


### PR DESCRIPTION
Added support for Ubuntu 22.04 which includes adding PHP repository for PHP7.4 due to no support for some PHP addons in PHP8.1 (namely geoip). This additional repository allows rinst access to latest PHP updates and features (for 7.4). Readme.md updated to reflect new addition.